### PR TITLE
Add ts-ignore statements in exports file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "querytyper",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "querytyper",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Convert SQL annotations into Typescript files",
   "main": "querytyper.js",
   "bin": {

--- a/querytyper.js
+++ b/querytyper.js
@@ -44,6 +44,12 @@ function writeIfChanged(filePath, fileContents) {
   console.info(`querytyper: wrote ${filePath}`)
 }
 
+function writeExportStatement(queryName) {
+  const tsIgnoreStatement = '// @ts-ignore'
+  const exportStatement = `export { ${queryName}, Result as ${queryName}Result, Arguments as ${queryName}Args } from './${queryName}.query';`
+  return tsIgnoreStatement + '\n' + exportStatement
+}
+
 queryTyperConfig.rootDirs.forEach(rootDir => {
   fs.readdirSync(rootDir).forEach(dirItem => {
     dirItemAbs = path.join(rootDir, dirItem)
@@ -114,7 +120,7 @@ queryTyperConfig.rootDirs.forEach(rootDir => {
     // Write exports file
     const exportsFileBody =
       generatedQueryNames.length > 0
-        ? generatedQueryNames.map(queryName => `export { ${queryName}, Result as ${queryName}Result, Arguments as ${queryName}Args } from './${queryName}.query';`).join('\n') + '\n'
+        ? generatedQueryNames.map(writeExportStatement).join('\n') + '\n'
         : ''
     writeIfChanged(path.join(dirItemAbs, queryTyperConfig.exportsFileName), codegenWarning + exportsFileBody)
   })


### PR DESCRIPTION
This PR adds a `// @ts-ignore` statement before each `export` statement in the exports file.

## Issue

If the `tsconfig.json` file includes the option `"isolatedModules": true`, an error like this is triggered:

```
server/service/admin/codegenExports.ts:30:50 - error TS1205: Cannot re-export a type when the '--isolatedModules' flag is provided.

30 export { updateQuay, Result as updateQuayResult, Arguments as updateQuayArgs } from './updateQuay.query'
                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is the case of all TS projects using Next.js v9+
https://github.com/zeit/next.js/issues/7959

## Fix

The easiest solution is to ignore these specific lines.

## Note

FYI when TS 3.7 will be released, we'll be able to just add one `// @ts-nocheck` at the beginning of the exports file to ignore the full file.
Additional info here https://devblogs.microsoft.com/typescript/announcing-typescript-3-7-beta/
